### PR TITLE
Start Channels enum at -1 to have CH_FL at 0 (and match other arrays)

### DIFF
--- a/Include/downmix.h
+++ b/Include/downmix.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 enum {
-	CH_UNMAPPED = 0,
+	CH_UNMAPPED = -1,
 	CH_FL,
 	CH_FR,
 	CH_CTR,


### PR DESCRIPTION
Possible fix to right channel missing (discussion in [aos-avp #1522](https://github.com/nova-video-player/aos-AVP/issues/1522))