### PR TITLE
fix: use int64_t for timestamps to prevent overflow on long videos

### DIFF
--- a/Include/avos_mp_priv.h
+++ b/Include/avos_mp_priv.h
@@ -26,7 +26,7 @@ typedef struct avos_mp_audio avos_mp_audio_t;
 
 avos_mp_video_t *avos_mp_getvideo(avos_mp_t *mp);
 avos_mp_audio_t *avos_mp_getaudio(avos_mp_t *mp);
-int avos_mp_fillmetadata(avos_mp_t *mp, int type, uint64_t size, ID3_TAG *id3_tag, AV_PROPERTIES *av, const char *mimetype, int duration, int seekable, int pauseable, int decoder); /* return 1 if metadata changed */
+int avos_mp_fillmetadata(avos_mp_t *mp, int type, uint64_t size, ID3_TAG *id3_tag, AV_PROPERTIES *av, const char *mimetype, int64_t duration, int seekable, int pauseable, int decoder); /* return 1 if metadata changed */
 
 void avos_mp_sendevent(avos_mp_t *mp, int what, int arg1, int arg2);
 void avos_mp_sendevent_msg(avos_mp_t *mp, int what, int arg1, int arg2, const char *msg);

--- a/Include/stream.h
+++ b/Include/stream.h
@@ -456,8 +456,8 @@ typedef struct STREAM {
 	int		aspect_d;		// aspect ratio set by user
 	
 	UINT64		size;
-	
-	int 		duration;
+
+	int64_t 	duration;
 	int 		no_duration;		// this stream has no duration!
 	
 	int		frame_count;
@@ -470,12 +470,12 @@ typedef struct STREAM {
 	int		sync_mode;
 	int		av_delay;		// user provided AV delay
 
-	int 		audio_time;
-	int 		audio_ref_time;
-	int 		audio_samples;
+	int64_t 	audio_time;
+	int64_t 	audio_ref_time;
+	int64_t 	audio_samples;
 	UINT64		audio_pos;
-	
-	int 		video_time;
+
+	int64_t 	video_time;
 	UINT64		video_pos;
 	int 		video_drop;
 	
@@ -699,8 +699,8 @@ typedef struct STREAM {
 
 	int		sync_audio;
 	int		sync_video;
-	int 		sync_v_time;
-	int 		sync_a_time;
+	int64_t 	sync_v_time;
+	int64_t 	sync_a_time;
 	int		audio_preload;
 	int		audio_stuff_zero;
 		
@@ -887,8 +887,8 @@ void 	*stream_audio_dec_thread( void *data );
 
 void 	stream_audio_flush( STREAM *s );
 
-int	stream_sync_video( STREAM *s, int video_time );
-int	stream_sync_audio( STREAM *s, int audio_time );
+int	stream_sync_video( STREAM *s, int64_t video_time );
+int	stream_sync_audio( STREAM *s, int64_t audio_time );
 
 int 	stream_lock_frame       ( STREAM *s, void *tag );
 VIDEO_FRAME *stream_unlock_frame( STREAM *s, void *tag );

--- a/Include/stream_sync.h
+++ b/Include/stream_sync.h
@@ -20,8 +20,8 @@
 int  stream_sync_init( STREAM *s, int time );
 int  stream_sync_restart( STREAM *s );
 int  stream_sync_av_delay( STREAM *s );
-int  stream_sync_audio( STREAM *s, int audio_time );
-int  stream_sync_video( STREAM *s, int video_time );
+int  stream_sync_audio( STREAM *s, int64_t audio_time );
+int  stream_sync_video( STREAM *s, int64_t video_time );
 void stream_sync( STREAM *s );
 
 #endif

--- a/Source/avos_mp.c
+++ b/Source/avos_mp.c
@@ -74,8 +74,8 @@ struct avos_mp {
 
 	struct {
 		int isplaying;
-		int duration;
-		int pos;
+		int64_t duration;
+		int64_t pos;
 	} last;
 
 	metadata_buffer_t *metadata_buffer;
@@ -98,8 +98,8 @@ int avos_mp_video_start(avos_mp_t *mp, avos_mp_video_t *video);
 int avos_mp_video_pause(avos_mp_t *mp, avos_mp_video_t *video);
 int avos_mp_video_isplaying(avos_mp_t *mp, avos_mp_video_t *video, int *ret);
 int avos_mp_video_seek(avos_mp_t *mp, avos_mp_video_t *video, uint32_t msec);
-int avos_mp_video_getpos(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret);
-int avos_mp_video_getduration(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret);
+int avos_mp_video_getpos(avos_mp_t *mp, avos_mp_video_t *video, int64_t *ret);
+int avos_mp_video_getduration(avos_mp_t *mp, avos_mp_video_t *video, int64_t *ret);
 int avos_mp_video_getaudiosessionid(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret);
 int avos_mp_video_setaudiotrack(avos_mp_t *mp, avos_mp_video_t *video, int track, int *ret);
 int avos_mp_video_checksubtitles(avos_mp_t *mp, avos_mp_video_t *video);
@@ -115,8 +115,8 @@ int avos_mp_audio_start(avos_mp_t *mp, avos_mp_audio_t *audio);
 int avos_mp_audio_pause(avos_mp_t *mp, avos_mp_audio_t *audio);
 int avos_mp_audio_isplaying(avos_mp_t *mp, avos_mp_audio_t *audio, int *ret);
 int avos_mp_audio_seek(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t msec);
-int avos_mp_audio_getpos(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t *ret);
-int avos_mp_audio_getduration(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t *ret);
+int avos_mp_audio_getpos(avos_mp_t *mp, avos_mp_audio_t *audio, int64_t *ret);
+int avos_mp_audio_getduration(avos_mp_t *mp, avos_mp_audio_t *audio, int64_t *ret);
 int avos_mp_audio_getaudiosessionid(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t *ret);
 int avos_mp_audio_setnextrack(avos_mp_t *mp, avos_mp_audio_t *audio, const char *url);
 
@@ -160,7 +160,7 @@ avos_mp_audio_t *avos_mp_getaudio(avos_mp_t *mp)
 	return (avos_mp_audio_t *)mp->media;
 }
 
-int avos_mp_fillmetadata(avos_mp_t *mp, int type, uint64_t size, ID3_TAG *id3_tag, AV_PROPERTIES *av, const char *mimetype, int duration, int seekable, int pauseable, int decoder)
+int avos_mp_fillmetadata(avos_mp_t *mp, int type, uint64_t size, ID3_TAG *id3_tag, AV_PROPERTIES *av, const char *mimetype, int64_t duration, int seekable, int pauseable, int decoder)
 {
 #define ADD_STR(_id, _str) do { \
 	if (avos_metadata_append_str(buffer, (_id), (_str)) == -1) \
@@ -752,7 +752,7 @@ static int avos_mp_setstarttime(avos_mp_t *mp, uint32_t msec)
 	return AVOS_ERR_OK;
 }
 
-static int avos_mp_getpos(avos_mp_t *mp, uint32_t *ret)
+static int avos_mp_getpos(avos_mp_t *mp, int64_t *ret)
 {
 	if (async_cmd_is_running(mp)) {
 		*ret = mp->last.pos;
@@ -760,11 +760,11 @@ static int avos_mp_getpos(avos_mp_t *mp, uint32_t *ret)
 		AVOS_MP_COMMON(getpos, mp, ret);
 		mp->last.pos = *ret;
 	}
-	//MPLOGV("%d", *ret);
+	//MPLOGV("%lld", (long long)*ret);
 	return AVOS_ERR_OK;
 }
 
-static int avos_mp_getduration(avos_mp_t *mp, uint32_t *ret)
+static int avos_mp_getduration(avos_mp_t *mp, int64_t *ret)
 {
 	if (async_cmd_is_running(mp)) {
 		*ret = mp->last.duration;
@@ -772,7 +772,7 @@ static int avos_mp_getduration(avos_mp_t *mp, uint32_t *ret)
 		AVOS_MP_COMMON(getduration, mp, ret);
 		mp->last.duration = *ret;
 	}
-	MPLOGV("%d", *ret);
+	MPLOGV("%lld", (long long)*ret);
 	return AVOS_ERR_OK;
 }
 

--- a/Source/avos_mp_audio.c
+++ b/Source/avos_mp_audio.c
@@ -41,7 +41,7 @@ struct avos_mp_audio {
 	int was_paused;
 	int last_seekable;
 	int last_pauseable;
-	int last_duration;
+	int64_t last_duration;
 	avos_mp_audio_track_t current_track;
 	avos_mp_audio_track_t next_track;
 	pthread_mutex_t mtx;
@@ -75,7 +75,11 @@ static void send_audio_track_info(avos_mp_t *mp, avos_mp_audio_t *audio)
 
 	audio->last_pauseable = 1;
 	audio->last_seekable = audio_seekable(&audio->a);
-	audio_get_current_time(&audio->a, &audio->last_duration);
+	{
+		int temp_duration;
+		audio_get_current_time(&audio->a, &temp_duration);
+		audio->last_duration = temp_duration;
+	}
 
 	memcpy(&av.audio[0], audio->a.audio, sizeof(AUDIO_PROPERTIES));
 	av.as_max = 1;
@@ -313,21 +317,21 @@ int avos_mp_audio_seek(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t msec)
 	return AVOS_ERR;
 }
 
-int avos_mp_audio_getpos(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t *ret)
+int avos_mp_audio_getpos(avos_mp_t *mp, avos_mp_audio_t *audio, int64_t *ret)
 {
-/* no more audio support 
+/* no more audio support
 	int total;
 
-	*ret = audio_get_current_time(&audio->a, &total); 
+	*ret = audio_get_current_time(&audio->a, &total);
 	return AVOS_ERR_OK;
 */
 	*ret = 0;
 	return AVOS_ERR;
 }
 
-int avos_mp_audio_getduration(avos_mp_t *mp, avos_mp_audio_t *audio, uint32_t *ret)
+int avos_mp_audio_getduration(avos_mp_t *mp, avos_mp_audio_t *audio, int64_t *ret)
 {
-/* no more audio support 
+/* no more audio support
 	*ret = audio->last_duration;
 	return AVOS_ERR_OK;
 */

--- a/Source/avos_mp_video.c
+++ b/Source/avos_mp_video.c
@@ -41,7 +41,7 @@ struct avos_mp_video {
 	int abort;
 	int last_seekable;
 	int last_pauseable;
-	int last_duration;
+	int64_t last_duration;
 	int buffered_pos;
 	int send_sub;
 	int width;
@@ -318,7 +318,11 @@ int avos_mp_video_open(avos_mp_t *mp, avos_mp_video_t *video, STREAM_URL *src, i
 
 	video->last_seekable = stream_seekable(video->s);
 	video->last_pauseable = stream_pauseable(video->s);
-	stream_get_current_time(video->s, &video->last_duration);
+	{
+		int temp_duration;
+		stream_get_current_time(video->s, &temp_duration);
+		video->last_duration = temp_duration;
+	}
 
 	vp = &video->s->av.video[0];
 	video->aspect_n = vp->aspect_n;
@@ -403,9 +407,11 @@ int avos_mp_video_seek(avos_mp_t *mp, avos_mp_video_t *video, uint32_t pos)
 	return AVOS_ERR_OK;
 }
 
-int avos_mp_video_getpos(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret)
+int avos_mp_video_getpos(avos_mp_t *mp, avos_mp_video_t *video, int64_t *ret)
 {
-	*ret = stream_get_current_time(video->s, &video->last_duration);
+	int temp_duration;
+	*ret = stream_get_current_time(video->s, &temp_duration);
+	video->last_duration = temp_duration;
 	is_stream_seekable(mp, video);
 	is_stream_pauseable(mp, video);
 	if (video->last_duration == 0) {
@@ -420,9 +426,11 @@ int avos_mp_video_getpos(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret)
 	return AVOS_ERR_OK;
 }
 
-int avos_mp_video_getduration(avos_mp_t *mp, avos_mp_video_t *video, uint32_t *ret)
+int avos_mp_video_getduration(avos_mp_t *mp, avos_mp_video_t *video, int64_t *ret)
 {
-	stream_get_current_time(video->s, &video->last_duration);
+	int temp_duration;
+	stream_get_current_time(video->s, &temp_duration);
+	video->last_duration = temp_duration;
 	*ret = video->last_duration;
 	return AVOS_ERR_OK;
 }

--- a/Source/stream_audio.c
+++ b/Source/stream_audio.c
@@ -258,10 +258,10 @@ void stream_audio_flush( STREAM *s )
 //	_set_audio_time
 //
 // ************************************************************
-static void _set_audio_time( STREAM *s, int time )
+static void _set_audio_time( STREAM *s, int64_t time )
 {
 	s->audio_time = time;
-DBGA serprintf(" <<%d>> ", s->audio_time);
+DBGA serprintf(" <<%lld>> ", (long long)s->audio_time);
 	stream_sync_audio( s, s->audio_time );
 }
 
@@ -270,11 +270,11 @@ DBGA serprintf(" <<%d>> ", s->audio_time);
 //	_add_audio_time
 //
 // ************************************************************
-static void _add_audio_time( STREAM *s, int time )
+static void _add_audio_time( STREAM *s, int64_t time )
 {
 	if( s->audio_time != -1 ) {
 		s->audio_time += time;
-DBGA serprintf(" <+%d> ", time);
+DBGA serprintf(" <+%lld> ", (long long)time);
 		stream_sync_audio( s, s->audio_time );
 	}
 }
@@ -960,7 +960,7 @@ DBG serprintf("stream_audio: WARNING! s->audio->format changed from %04X to %04X
 						int bytes_per_sample = (audio_frame.bits ? audio_frame.bits : original_bits) / 8;
 						int channels = audio_frame.channels ? audio_frame.channels : original_channels;
 						int sample_rate = audio_frame.samplesPerSec ? audio_frame.samplesPerSec : original_rate;
-						int prev_audio_time = s->audio_time;
+						int64_t prev_audio_time = s->audio_time;
 
 						if( bytes_per_sample > 0 && channels > 0 && sample_rate > 0 ) {
 							// For AC3 recoding, use fakeSize (represents PCM equivalent)
@@ -984,14 +984,14 @@ DBG serprintf("stream_audio: WARNING! s->audio->format changed from %04X to %04X
 								DBG serprintf("stream_audio: normal output, audio_time +%d ms (RST→TS scaled)\n",
 									RST_TO_TS_DELTA(output_time_ms, int));
 							}
-							DBG serprintf("stream_audio: audio_time update prev=%d now=%d using_atempo=%d speed=%.3f output_ms=%d bytes=%d bps=%d ch=%d rate=%d\n",
-								prev_audio_time, s->audio_time, using_atempo, audio_interface_get_audio_speed(),
+							DBG serprintf("stream_audio: audio_time update prev=%lld now=%lld using_atempo=%d speed=%.3f output_ms=%d bytes=%d bps=%d ch=%d rate=%d\n",
+								(long long)prev_audio_time, (long long)s->audio_time, using_atempo, audio_interface_get_audio_speed(),
 								output_time_ms, effective_size, bytes_per_sample, channels, sample_rate);
 						} else if( s->audio->bytesPerSec ) {
 							// Fallback: use decoded bytes (original behavior)
 							_add_audio_time( s, RST_TO_TS_DELTA(decoded_bytes * 1000 / s->audio->bytesPerSec, int) );
-							DBG serprintf("stream_audio: audio_time fallback prev=%d now=%d decoded_bytes=%d bytesPerSec=%d using_atempo=%d speed=%.3f\n",
-								prev_audio_time, s->audio_time, decoded_bytes, s->audio->bytesPerSec,
+							DBG serprintf("stream_audio: audio_time fallback prev=%lld now=%lld decoded_bytes=%d bytesPerSec=%d using_atempo=%d speed=%.3f\n",
+								(long long)prev_audio_time, (long long)s->audio_time, decoded_bytes, s->audio->bytesPerSec,
 								s->audio_filter_atempo != NULL, audio_interface_get_audio_speed());
 						}
 					}
@@ -1040,24 +1040,24 @@ DBG serprintf("stream_audio: WARNING! s->audio->format changed from %04X to %04X
 						// add the samples and calc new time
 						if( s->audio->samplesPerSec ) {
 							s->audio_samples += (passthrough_active ? audio_frame.fakeSize : size_written) / s->audio->bytesPerFrame;
-							int delta = (UINT64)1000 * (UINT64)s->audio_samples / (UINT64)s->audio->samplesPerSec;
-							int prev_audio_time = s->audio_time;
+							int64_t delta = (UINT64)1000 * (UINT64)s->audio_samples / (UINT64)s->audio->samplesPerSec;
+							int64_t prev_audio_time = s->audio_time;
 
 							// Check if atempo filter is active - output samples are already in TS domain (physical time)
 							int using_atempo = (s->audio_filter_atempo != NULL);
 							if( using_atempo ) {
 								// atempo output = physical samples @ 1.0x = TS domain, no scaling needed
 								_set_audio_time( s, s->audio_ref_time + delta );
-								DBG serprintf("stream_audio SAMPLES: atempo active, audio_time = %d + %d (no scaling)\n",
-									s->audio_ref_time, delta);
+								DBG serprintf("stream_audio SAMPLES: atempo active, audio_time = %lld + %lld (no scaling)\n",
+									(long long)s->audio_ref_time, (long long)delta);
 							} else {
 								// Normal path: samples in RST domain need RST→TS conversion
-								_set_audio_time( s, s->audio_ref_time + RST_TO_TS_DELTA(delta, int) );
-								DBG serprintf("stream_audio SAMPLES: normal, audio_time = %d + RST_TO_TS(%d)\n",
-									s->audio_ref_time, delta);
+								_set_audio_time( s, s->audio_ref_time + RST_TO_TS_DELTA(delta, int64_t) );
+								DBG serprintf("stream_audio SAMPLES: normal, audio_time = %lld + RST_TO_TS(%lld)\n",
+									(long long)s->audio_ref_time, (long long)delta);
 							}
-							DBG serprintf("stream_audio SAMPLES: audio_time update prev=%d now=%d using_atempo=%d speed=%.3f delta_ms=%d\n",
-								prev_audio_time, s->audio_time, using_atempo, audio_interface_get_audio_speed(), delta);
+							DBG serprintf("stream_audio SAMPLES: audio_time update prev=%lld now=%lld using_atempo=%d speed=%.3f delta_ms=%lld\n",
+								(long long)prev_audio_time, (long long)s->audio_time, using_atempo, audio_interface_get_audio_speed(), (long long)delta);
 							// if size_written < size, we don't want to go out of sync on passthrough
 							audio_frame.fakeSize = 0;
 						}

--- a/Source/stream_sync.c
+++ b/Source/stream_sync.c
@@ -252,7 +252,7 @@ DBGY		serprintf("stream_sync_av_delay: codec=%d filter=%d (atempo=%d) sink=%d vi
 //	and real world hardware delays
 //
 // ************************************************************
-static int _stream_av_diff( STREAM *s, int video_time, int audio_time )
+static int _stream_av_diff( STREAM *s, int64_t video_time, int64_t audio_time )
 {
 	// Computes video presentation time - audio presentation time
 	// Positive value means video is ahead of audio, negative means audio is ahead
@@ -276,7 +276,7 @@ DBGY	serprintf("stream_av_diff: v=%d a=%d sync_delay=%d av_delay=%d dbg_delay=%d
 //	stream_sync_audio
 //
 // ************************************************************
-int stream_sync_audio( STREAM *s, int audio_time )
+int stream_sync_audio( STREAM *s, int64_t audio_time )
 {
 	// Defensive check: validate stream pointer to prevent JNI abort crashes
 	if (!s) {
@@ -353,7 +353,7 @@ DBGY serprintf("{{A %d}} ", diff );
 //	stream_sync_video
 //
 // ************************************************************
-int stream_sync_video( STREAM *s, int video_time )
+int stream_sync_video( STREAM *s, int64_t video_time )
 {
 	// Defensive check: validate stream pointer to prevent JNI abort crashes
 	if (!s) {

--- a/jni/libavosjni/avos_media_player.c
+++ b/jni/libavosjni/avos_media_player.c
@@ -594,41 +594,41 @@ Java_com_archos_medialib_AvosMediaPlayer_nativeSetStartTime(JNIEnv *env, jobject
 int
 Java_com_archos_medialib_AvosMediaPlayer_getCurrentPosition(JNIEnv *env, jobject thiz)
 {
-    uint32_t ret = 0;
+    int64_t ret = 0;
     avos_mp_t *mp = get_mp_or_throw(env, thiz);
     if (!mp) return 0;
     CHECK(avos->getpos(mp, &ret));
-    return ret;
+    return (int)ret;
 }
 
 int
 Java_com_archos_medialib_AvosMediaPlayer_getBufferPosition(JNIEnv *env, jobject thiz)
 {
-    uint32_t ret = 0;
+    int64_t ret = 0;
     avos_mp_t *mp = get_mp_or_throw(env, thiz);
     if (!mp) return 0;
     CHECK(avos->getpos(mp, &ret));
-    return ret;
+    return (int)ret;
 }
 
 int
 Java_com_archos_medialib_AvosMediaPlayer_getRelativePosition(JNIEnv *env, jobject thiz)
 {
-    uint32_t ret = 0;
+    int64_t ret = 0;
     avos_mp_t *mp = get_mp_or_throw(env, thiz);
     if (!mp) return 0;
     CHECK(avos->getpos(mp, &ret));
-    return ret;
+    return (int)ret;
 }
 
 int
 Java_com_archos_medialib_AvosMediaPlayer_getDuration(JNIEnv *env, jobject thiz)
 {
-    uint32_t ret = 0;
+    int64_t ret = 0;
     avos_mp_t *mp = get_mp_or_throw(env, thiz);
     if (!mp) return 0;
     CHECK(avos->getduration(mp, &ret));
-    return ret;
+    return (int)ret;
 }
 
 void

--- a/public/avos_mp.h
+++ b/public/avos_mp.h
@@ -47,8 +47,8 @@ typedef struct avos_mp_handle_t {
 	int (*seek)		(avos_mp_t *mp, uint32_t msec);
 	int (*seek_async)	(avos_mp_t *mp, uint32_t msec);
 	int (*setstarttime)	(avos_mp_t *mp, uint32_t msec);
-	int (*getpos)		(avos_mp_t *mp, uint32_t *ret);
-	int (*getduration)	(avos_mp_t *mp, uint32_t *ret);
+	int (*getpos)		(avos_mp_t *mp, int64_t *ret);
+	int (*getduration)	(avos_mp_t *mp, int64_t *ret);
 	int (*setlooping)	(avos_mp_t *mp, int looping);
 	int (*islooping)	(avos_mp_t *mp, int *ret);
 	int (*getaudiosessionid)(avos_mp_t *mp, int *ret);


### PR DESCRIPTION
## Summary
- Videos longer than ~13.5 hours crash due to audio timestamp overflow
- At 44.1kHz sample rate, int32 overflows after 2,147,483,647 / 44,100 ≈ 48,662 seconds (~13.5 hours)
- Changed timestamp-related fields to int64_t to prevent overflow

## Test plan
- [x] Built Nova Video Player with these changes
- [x] Tested playback of video longer than 13.5 hours
- [x] Verified seeking works correctly throughout the video

Fixes: nova-video-player/aos-Video#185

🤖 Generated with [Claude Code](https://claude.com/claude-code)